### PR TITLE
Fix: dedupe /me/profile requests with SWR and local JWT validation

### DIFF
--- a/src/feature/hooks/useAuth.ts
+++ b/src/feature/hooks/useAuth.ts
@@ -3,30 +3,42 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000';
+function parseJwt<T = any>(token: string): T | null {
+  try {
+    const payload = token.split('.')[1];
+    const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/'));
+    return JSON.parse(decodeURIComponent(escape(json)));
+  } catch {
+    return null;
+  }
+}
 
 export function useAuth() {
   const [token, setToken] = useState<string | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const router = useRouter();
 
-  // 初期化: localStorageからトークンを読み込み
   useEffect(() => {
     const storedToken = localStorage.getItem('access_token');
     if (storedToken) {
-      setToken(storedToken);
-      setIsAuthenticated(true);
+      // 期限チェック（expは秒単位UNIX時刻）
+      const payload = parseJwt<{ exp?: number }>(storedToken);
+      const now = Math.floor(Date.now() / 1000);
+      if (payload?.exp && payload.exp > now) {
+        setToken(storedToken);
+        setIsAuthenticated(true);
+      } else {
+        localStorage.removeItem('access_token');
+      }
     }
   }, []);
 
-  // ログイン成功時に呼ぶ
   const login = (newToken: string) => {
     localStorage.setItem('access_token', newToken);
     setToken(newToken);
     setIsAuthenticated(true);
   };
 
-  // ログアウト処理
   const logout = () => {
     localStorage.removeItem('access_token');
     setToken(null);
@@ -34,36 +46,19 @@ export function useAuth() {
     router.push('/login');
   };
 
-  // サーバーに問い合わせてトークンの有効性を確認する関数（任意）
+  // ★ ネットワークには行かずローカルで有効性を判定（重複リクエスト防止）
   const validateToken = async (): Promise<boolean> => {
     if (!token) return false;
-
-    try {
-      const res = await fetch(`${API_BASE}/me/profile`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-
-      // 無効なら削除
-      if (!res.ok) {
-        localStorage.removeItem('access_token');
-        setToken(null);
-        setIsAuthenticated(false);
-        return false;
-      }
-      return true;
-    } catch (err) {
+    const payload = parseJwt<{ exp?: number }>(token);
+    const now = Math.floor(Date.now() / 1000);
+    const ok = !!(payload?.exp && payload.exp > now);
+    if (!ok) {
       localStorage.removeItem('access_token');
       setToken(null);
       setIsAuthenticated(false);
-      return false;
     }
+    return ok;
   };
 
-  return {
-    token,
-    isAuthenticated,
-    login,
-    logout,
-    validateToken,
-  };
+  return { token, isAuthenticated, login, logout, validateToken };
 }

--- a/src/lib/swr.ts
+++ b/src/lib/swr.ts
@@ -1,0 +1,32 @@
+import useSWR, { SWRConfiguration } from 'swr';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000';
+
+const fetcher = async (path: string) => {
+  const token = localStorage.getItem('access_token');
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const err = new Error(body?.detail || `HTTP ${res.status}`);
+    // エラーにstatusを付与して呼び出し側で分岐できるように
+    // @ts-expect-error
+    err.status = res.status;
+    throw err;
+  }
+  return res.json();
+};
+
+export const swrOptions: SWRConfiguration = {
+  fetcher,
+  revalidateOnFocus: false,
+  revalidateOnReconnect: false,
+  dedupingInterval: 60_000, // 1分間は同一キーの重複をまとめる
+  keepPreviousData: true,
+};
+
+export function useApi<T = any>(key: string | null) {
+  return useSWR<T>(key, fetcher, swrOptions);
+}


### PR DESCRIPTION
# Fix: dedupe /me/profile requests with SWR and local JWT validation

## Branch
`fix/profile-request-storm`

---

## 背景 / 問題
- `/me/profile` への GET が同一ページ / 同時刻に多数発火し、ログが「200 OK」で埋まる問題。
- 原因は以下の複合要因：
  - 各所で独自に `fetch` している
  - Next.js 開発環境の StrictMode での再レンダー
  - フォーカス時・再接続時の自動再検証

---

## 変更概要
### 1. SWR導入 & 共通化
- **新規追加** `src/lib/swr.ts`
  - 共通 `fetcher` の実装
  - `revalidateOnFocus=false`
  - `revalidateOnReconnect=false`
  - `dedupingInterval=60_000` → 同一キーでの重複リクエストを1本に集約

### 2. プロフィール取得の一元化
- `src/feature/hooks/useUserSummary.ts` を **SWRベース**に置き換え
  - キーを `'/me/profile'` に統一
  - `isAuthenticated` が `true` のときのみ発火
  - 401 / 404 を受けた場合は自動で `logout()` 呼び出し

### 3. トークン検証のローカル化
- `src/feature/hooks/useAuth.ts`
  - `validateToken()` をサーバー問い合わせではなく **JWTの `exp` をローカル検証**に変更
  - 初期化時にも `exp` をチェックし、期限切れなら即座に破棄

### 4. 利用上のガード
- 同一画面で複数回 `useUserSummary()` を呼ばない
- 親コンポーネントで1回呼び出して子へ `props` で渡す設計を推奨

---

## 変更ファイル
- **[新規]** `src/lib/swr.ts`
- **[更新]** `src/feature/hooks/useUserSummary.ts`
- **[更新]** `src/feature/hooks/useAuth.ts`

---

## 動作確認手順
1. `npm install swr`（未導入の場合は実行）  
   TypeScriptで型エラーが出た場合は `npm i -D @types/swr` を追加
2. ログイン後、トップページまたはプロフィール取得画面を表示
3. Networkタブで `GET /me/profile` が **1本に集約**されていることを確認
4. トークンの `exp` を過去時刻に書き換え、**期限切れ時は自動でログアウト**されることを確認
5. ページフォーカス・再接続時にも意図しない再リクエストが走らないことを確認

---

## リスク / 影響範囲
- SWRに依存するため、今後のデータ取得フックもSWRへ統一すると整合性が高まる
- JWTの有効期限はローカル検証に寄せたため、**サーバー側のブラックリスト等は即時反映されない**
  - 今回は「リクエスト嵐抑止」を優先

---

## 関連issue
#26 