### PR TITLE
Feature/make room by soro

### DIFF
--- a/src/app/newroom/page.tsx
+++ b/src/app/newroom/page.tsx
@@ -1,49 +1,49 @@
 'use client';
 
 import Header from '@/feature/Header/Header';
-import ProfileCard from '@/feature/Profile/ProfileCard';
-import GoLoginButton from '@/feature/GoLogin/GoLoginButton';
-import StartButtons from '@/feature/StartButtons/StartButtons';
-import { useUserSummary } from '@/feature/hooks/useUserSummary';
-import LogoutButton from '@/feature/Logout/LogoutButton';
 import NewRoomInput from '@/feature/NewRoomInput/NewRoomInput';
-
 import React, { useState } from 'react';
 import NewRoomGoal from '@/feature/NewRoomGoal/NewRoomGoal';
 import NewRoomButton from '@/feature/NewRoomButton/NewRoomButton';
 
 export default function NewRoomPage() {
-    const [roomName, setRoomName] = useState('');
-    const [goal, setGoal] = useState('');
-    const [number, setNumber] = useState('');
-    const [unit, setUnit] = useState('');
+  const [roomName, setRoomName] = useState(''); // 将来 rooms.name を追加したら送る
+  const [goal, setGoal] = useState('');
+  const [number, setNumber] = useState('');
+  const [unit, setUnit] = useState('');
 
-    return (
-        <>
-            <Header />
-            <div className="m-auto px-12 max-w-100 flex flex-col min-h-screen" style={{ backgroundColor: '#144895' }}>
-                <main>
-                    <div className="w-full flex flex-col items-center space-y-4 pt-48 pb-10">
-                        <p className="text-[var(--secondary)]">ルーム名を入力する</p>
-                        <NewRoomInput
-                            value={roomName}
-                            onChange={setRoomName}
-                        />
-                    </div>
-                    <div className="w-full flex flex-col items-center space-y-4 pb-48">
-                        <p className="text-[var(--secondary)]">目標を入力する</p>
-                        <NewRoomGoal
-                            goal={goal}
-                            number={number}
-                            unit={unit}
-                            onChangeGoal={setGoal}
-                            onChangeNumber={setNumber}
-                            onChangeUnit={setUnit}
-                        />
-                    </div>
-                    <NewRoomButton />
-                </main>
-            </div>
-        </>
-    )
+  return (
+    <>
+      <Header />
+      <div className="m-auto px-12 max-w-100 flex flex-col min-h-screen" style={{ backgroundColor: '#144895' }}>
+        <main>
+          <div className="w-full flex flex-col items-center space-y-4 pt-48 pb-10">
+            <p className="text-[var(--secondary)]">ルーム名を入力する</p>
+            <NewRoomInput value={roomName} onChange={setRoomName} />
+          </div>
+
+          <div className="w-full flex flex-col items-center space-y-4 pb-48">
+            <p className="text-[var(--secondary)]">目標を入力する</p>
+            <NewRoomGoal
+              goal={goal}
+              number={number}
+              unit={unit}
+              onChangeGoal={setGoal}
+              onChangeNumber={setNumber}
+              onChangeUnit={setUnit}
+            />
+          </div>
+
+          {/* 入力値をAPI実行ボタンに渡す */}
+          <div className="w-full flex flex-col items-center pb-20">
+            <NewRoomButton
+              title={goal}
+              targetValue={Number(number) || 0}  // 数値に変換（未入力は0）
+              unit={unit}
+            />
+          </div>
+        </main>
+      </div>
+    </>
+  );
 }

--- a/src/feature/hooks/useAuth.ts
+++ b/src/feature/hooks/useAuth.ts
@@ -1,3 +1,4 @@
+//useAuth.ts
 'use client';
 
 import { useState, useEffect } from 'react';

--- a/src/feature/hooks/useUserSummary.mock.ts
+++ b/src/feature/hooks/useUserSummary.mock.ts
@@ -1,3 +1,4 @@
+
 'use client';
 
 export type Summary = {

--- a/src/feature/hooks/useUserSummary.ts
+++ b/src/feature/hooks/useUserSummary.ts
@@ -1,3 +1,4 @@
+//useSummary.ts
 'use client';
 
 import { useApi } from '@/lib/swr';

--- a/src/feature/newroombutton/newroombutton.tsx
+++ b/src/feature/newroombutton/newroombutton.tsx
@@ -1,12 +1,61 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase/client'; // ← ここはあなたの supabase 初期化ファイルのパスに合わせてね
 
-export default function NewRoomButton() {
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8000';
+
+type Props = {
+  title: string;        // crystals.title
+  targetValue: number;  // crystals.target_value
+  unit: string;         // crystals.unit
+};
+
+export default function NewRoomButton({ title, targetValue, unit }: Props) {
   const router = useRouter();
+  const [loading, setLoading] = useState(false);
 
-  const handleClick = () => {
-    router.push('/solo'); // solo.tsx へ遷移
+  const handleClick = async () => {
+    try {
+      setLoading(true);
+
+      // Supabaseセッションからアクセストークン取得
+      const { data: sessionData, error: sessionErr } = await supabase.auth.getSession();
+      if (sessionErr || !sessionData.session?.access_token) {
+        alert('ログインが必要です');
+        return;
+      }
+      const token = sessionData.session.access_token;
+
+      // バックエンドへリクエスト
+      const res = await fetch(`${API_BASE}/rooms/solo`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          title,
+          target_value: targetValue,
+          unit,
+        }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.detail || `HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      // 成功したらルームページへ
+      router.push(`/rooms/${data.room_id}`);
+    } catch (e: any) {
+      console.error(e);
+      alert(`作成に失敗しました: ${e.message ?? e}`);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -15,8 +64,9 @@ export default function NewRoomButton() {
         type="button"
         className="primary-btn w-full"
         onClick={handleClick}
+        disabled={loading}
       >
-        作成する
+        {loading ? '作成中...' : '作成する'}
       </button>
     </div>
   );


### PR DESCRIPTION
# プルリクエスト: フロントエンド – ソロルーム作成フロー

---

## 🟦 タイトル
Feat: ソロルーム作成フローをバックエンドAPIと統合

---

## 📝 概要
このPRでは **ソロルーム作成機能** をフロントエンドに実装しました。  
ユーザーがルーム名・目標値・単位を入力し、バックエンドAPIを通してソロルームを作成できるようになります。  

- `NewRoomPage` ページを追加し、入力フォームを配置  
- `NewRoomButton` コンポーネントでAPIリクエストを実装  
- Supabaseのセッショントークンを取得し、`Authorization: Bearer` を付与  
- 作成成功後は対象ルームの詳細ページにリダイレクト  

---

## 🔄 変更内容

### `src/app/newroom/page.tsx` (NewRoomPage)
- 以下の状態管理を追加:
  - `roomName`
  - `goal`
  - `number`
  - `unit`
- `NewRoomInput` と `NewRoomGoal` を利用して入力を受け取る  
- `NewRoomButton` に入力内容を渡してAPI呼び出し  

### `src/feature/NewRoomButton/NewRoomButton.tsx`
- バックエンド `/rooms/solo` にPOSTリクエストを実装  
- **Supabaseセッショントークン** を取得し、ヘッダーに付与  
- ボタン押下時はローディング表示に切り替え  
- 作成成功時は `/rooms/{room_id}` へ遷移  
- 失敗時はエラーメッセージをアラート表示  

---

## 📸 動作フロー
1. `/newroom` ページに遷移  
2. フォームで以下を入力:
   - ルーム名  
   - 目標値（数値＋単位）  
3. 「作成する」ボタンを押下  
4. → API呼び出し → ソロルーム作成  
5. 作成成功後 `/rooms/{id}` にリダイレクト  

---

## ✅ チェックリスト
- [x] Supabaseセッションからトークンを正しく取得できる  
- [x] API呼び出し時にBearerトークンが付与されている  
- [x] エラー時にアラート表示が行われる  
- [x] 作成成功後にリダイレクトされる  

---

## 🚀 今後の課題
- アラートではなくトースト/スナックバーでの通知対応  
- チームルーム作成機能への拡張  

---

## 🖊️ コミット
```bash
git add . && git commit -m "Feat: ソロルーム作成フローをバックエンドAPIと統合" && git push